### PR TITLE
バグ修正や小さな改善．

### DIFF
--- a/Common/WinUtility.h
+++ b/Common/WinUtility.h
@@ -116,15 +116,16 @@ inline BOOL setWindowRect(HWND hwnd, LPCRECT rc, UINT flags = 0)
 //
 inline BOOL isAncestor(HWND hwnd1, HWND hwnd2)
 {
-	while (hwnd1)
-	{
-		if (hwnd1 == hwnd2)
-			return TRUE;
+	//while (hwnd1)
+	//{
+	//	if (hwnd1 == hwnd2)
+	//		return TRUE;
 
-		hwnd1 = ::GetParent(hwnd1);
-	}
+	//	hwnd1 = ::GetParent(hwnd1);
+	//}
 
-	return FALSE;
+	//return FALSE;
+	return hwnd1 == hwnd2 || ::IsChild(hwnd2, hwnd1);
 }
 
 //--------------------------------------------------------------------

--- a/Common/Window.h
+++ b/Common/Window.h
@@ -141,8 +141,8 @@ namespace Tools
 			UINT_PTR id, DWORD_PTR refData)
 		{
 //			MY_TRACE_FUNC("0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X", hwnd, message, wParam, lParam, id, refData);
-			TCHAR className[MAX_PATH] = {};
-			::GetClassName(hwnd, className, std::size(className));
+			//TCHAR className[MAX_PATH] = {};
+			//::GetClassName(hwnd, className, std::size(className));
 //			MY_TRACE_TSTR(className);
 
 			auto window = (Window*)refData;

--- a/EditBoxTweaker/Servant.h
+++ b/EditBoxTweaker/Servant.h
@@ -110,12 +110,12 @@ namespace fgo::editbox_tweaker
 			if (wcslen(font.name) != 0)
 			{
 				// DPIに合わせてフォントのサイズを調整します。
-				int dpi = ::GetSystemDpiForProcess(::GetCurrentProcess());
-				int height = ::MulDiv(font.height, dpi, 96);
+				//int dpi = ::GetSystemDpiForProcess(::GetCurrentProcess());
+				//int height = ::MulDiv(font.height, dpi, 96);
 
 				// HFONTを作成します。
 				// 複数行エディットボックスのWM_SETFONTでこのハンドルが渡されます。
-				font.handle = ::CreateFontW(height, 0,
+				font.handle = ::CreateFontW(font.height, 0,
 					0, 0, 0, 0, 0, 0, DEFAULT_CHARSET,
 					0, 0, 0, font.pitch, font.name);
 			}
@@ -235,7 +235,7 @@ namespace fgo::editbox_tweaker
 				case WM_SETFONT:
 					MY_TRACE(_T("WM_SETFONT, 0x%08X, 0x%08X\n"), wparam, lparam);
 					wparam = reinterpret_cast<WPARAM>(servant.font.handle); // handle is not null here.
-				//[[fallthrough]];
+					[[fallthrough]];
 				case WM_DESTROY:
 					::RemoveWindowSubclass(hwnd, subclassproc, id);
 					break;
@@ -270,16 +270,16 @@ namespace fgo::editbox_tweaker
 		// この構造体は::DispatchMesageA()を::DispatchMesageW()に置き換えるために使用されます。
 		//
 		struct {
-			inline static decltype(&::DispatchMessageA) hook = ::DispatchMessageW;
-			inline static decltype(hook) orig = ::DispatchMessageA;
+			constexpr static auto& hook = ::DispatchMessageW;
+			inline static decltype(&hook) orig = ::DispatchMessageA;
 		} DispatchMessageA;
 
 		//
 		// この構造体は::PeekMesageA()を::PeekMesageW()に置き換えるために使用されます。
 		//
 		struct {
-			inline static decltype(&::PeekMessageA) hook = ::PeekMessageW;
-			inline static decltype(hook) orig = ::PeekMessageA;
+			constexpr static auto& hook = ::PeekMessageW;
+			inline static decltype(&hook) orig = ::PeekMessageA;
 		} PeekMessageA;
 	} servant;
 }

--- a/Nest/Container/Container.h
+++ b/Nest/Container/Container.h
@@ -357,12 +357,34 @@ namespace fgo::nest
 
 					break;
 				}
+			case WM_KEYDOWN:
+			case WM_KEYUP:
+			case WM_CHAR:
+			case WM_DEADCHAR:
+			case WM_SYSKEYDOWN:
+			case WM_SYSKEYUP:
+			case WM_SYSCHAR:
+			case WM_SYSDEADCHAR:
+				{
+					// モーダルダイアログを閉じた直後などで
+					// ショートカットキーが利かなくなっていた問題に対処．
+					// メッセージをAviUtlのメインウィンドウに転送します．
+					return ::SendMessage(hive.aviutlWindow, message, wParam, lParam);
+				}
 			case WM_ACTIVATE:
 			case WM_COMMAND:
 			case WM_CLOSE:
 				{
 					// メッセージをそのままターゲットウィンドウに転送します。
 					return ::SendMessage(content->getHWND(), message, wParam, lParam);
+				}
+			case WM_SYSCOMMAND:
+				{
+					// Windows 標準のコマンドでないならターゲットウィンドウに転送して処理させます．
+					// これでサブウィンドウタイトルの右クリックメニューから名前の変更ができます．
+					if (wParam < 0xF000)
+						::PostMessage(content->getHWND(), message, wParam, lParam);
+					break;
 				}
 			}
 

--- a/Nest/DockSite.h
+++ b/Nest/DockSite.h
@@ -717,8 +717,13 @@ namespace fgo::nest
 						{
 							// クリックされたペインがシャトルを持っているなら
 							Shuttle* shuttle = pane->getCurrentShuttle();
-							if (shuttle)
+							if (shuttle) {
 								::SetFocus(*shuttle); // そのシャトルにフォーカスを当てます。
+								if (pane->hitTestCaption(point))
+									// キャプションをクリックしたときは，
+									// その親のサブウィンドウにフォーカスが移らないよう処理済み扱いにします．
+									return 0;
+							}
 						}
 					}
 

--- a/Nest/DockSite.h
+++ b/Nest/DockSite.h
@@ -400,14 +400,26 @@ namespace fgo::nest
 
 			if (id)
 			{
+				// 原点を切り替えたときボーダーの位置が変わらないよう調整します．
+				constexpr auto flip_border = [](auto& pane, int origin) {
+					if (pane->origin == origin) return;
+					pane->origin = origin;
+					if (pane->splitMode == Pane::SplitMode::none) return;
+
+					pane->border = -pane->borderWidth - pane->border;
+					switch (pane->splitMode) {
+					case Pane::SplitMode::horz: pane->border += pane->position.bottom - pane->position.top; break;
+					case Pane::SplitMode::vert: pane->border += pane->position.right - pane->position.left; break;
+					}
+				};
 				switch (id)
 				{
 				case CommandID::SPLIT_MODE_NONE: pane->setSplitMode(Pane::SplitMode::none); break;
 				case CommandID::SPLIT_MODE_VERT: pane->setSplitMode(Pane::SplitMode::vert); break;
 				case CommandID::SPLIT_MODE_HORZ: pane->setSplitMode(Pane::SplitMode::horz); break;
 
-				case CommandID::ORIGIN_TOP_LEFT: pane->origin = Pane::Origin::topLeft; break;
-				case CommandID::ORIGIN_BOTTOM_RIGHT: pane->origin = Pane::Origin::bottomRight; break;
+				case CommandID::ORIGIN_TOP_LEFT: flip_border(pane, Pane::Origin::topLeft); break;
+				case CommandID::ORIGIN_BOTTOM_RIGHT: flip_border(pane, Pane::Origin::bottomRight); break;
 
 				case CommandID::MOVE_TO_LEFT: pane->moveTab(ht, ht - 1); break;
 				case CommandID::MOVE_TO_RIGHT: pane->moveTab(ht, ht + 1); break;

--- a/Nest/Pane/Pane.h
+++ b/Nest/Pane/Pane.h
@@ -671,6 +671,11 @@ namespace fgo::nest
 						break;
 					}
 				}
+				if (limited)
+					// タブコントロールのサイズが変わらないと再描画が行われないらしい．
+					// 最大化モードで再描画を抑制中にレイアウトした後で移動が起こった場合，
+					// アーティファクトが残っていたので対処．
+					::InvalidateRect(tab, nullptr, FALSE);
 			}
 			// タブが1個以下なら
 			else


### PR DESCRIPTION
いくつか問題点を見つけて対処できたので提案します．

1. DirtyCheck のバグ修正:
   1. 何か編集を加えた直後にフレーム移動するなどでタイトルを更新すると `*` マークが消えた．
   2. 保存をしても `*` マークが消えなかった．
   3. 保存したあとフレーム移動するだけで編集済み扱いになって，AviUtl を閉じようとしたときメッセージが表示されていた．

   (i) と (iii) は色々勘違いっぽいコードだったことが原因だったようです．`Check()` 関数は `get()` 関数と名前が似ているため，役割を明確にする目的で `Update()` 関数に改名，戻り値も `void` にしました．

   (ii) は手動でタイトルから `*` マークを消すようにしました．

2. EditBoxTweaker の変更．
   1. DPIに合わせてフォントサイズを変える部分が実は逆効果だったので無効化．
   2. `[[fallthrough]];` のコメントアウトを解除．
   3. Detours でフックする関数宣言部分を少しコンパクトに．

   (i) について，実際にテストした画像がこちらです（いずれも Segoe UI, サイズ14）:
   - UIスケール100%:
     ![scale100](https://github.com/hebiiro/anti.aviutl.ultimate.plugin/assets/132639613/e814a773-26c0-41b8-a61b-8c483291c87d)

   - UIスケール125%:
     ![scale125](https://github.com/hebiiro/anti.aviutl.ultimate.plugin/assets/132639613/a7cf8cb1-543e-4eb4-a66c-94c47ec1b867)

   - UIスケール150%:
     ![scale150](https://github.com/hebiiro/anti.aviutl.ultimate.plugin/assets/132639613/ffcfe101-234e-4065-9281-19f7f4ef120c)

   ボックスとの比率が変わってきてしまっているのがわかると思います．いわば，比率の二重適用になっていたようでした．修正の方針としては無効化するか逆掛けするかでしょうが指定できるフォントサイズが整数に限られるため，逆掛けした場合 UIスケール > 100% のとき，違う数値を設定しても同じフォントサイズになることもあり調整しにくいと思い無効化する方針にしました．既存の設定が壊れる結果にはなりますが，以前だとスキップされていた整数値も設定できることになるのでいい面もあります．

   (ii) の`[[fallthrough]]` の部分は私の以前のプルリクの部分のようですが，これはその時のプロジェクトが C++14 をターゲットとしていた一方，`[[fallthrough]]` は C++17 以降だった名残です．今のプロジェクトは C++20 のようなのであったほうがいいです．自分で書いた部分なので自分で戻すことにしました．

   (iii) はどちらかというと個人的な趣向です．他の Detours に適用する構造体と型も統一できていると思います．

3. Nest の修正．
   1. いくつかの場面でショートカットキーの入力が無視されていたのを修正．
   2. フロート状態のサブウィンドウを，タイトル部分を右クリックで名前を変更できるように．
   3. ペインのボーダーの「左上原点 / 右上原点」を切り替えたとき，ボーダーの画面上の位置が変わってしまっていたのを修正．
   4. ついでにフロート状態のサブウィンドウにアイコンを設定．

   (i) について．Nest の `MainWindow` 以外のウィンドウにフォーカスがある状態で，例えばオブジェクトの長さを変えるダイアログを出してキャンセルした直後は一度マウス操作に戻ってフォーカスを切り替えなおすなどしないとショートカットキーを受け付けませんでした．他にもフロート状態のサブウィンドウのタイトル部分をクリックした直後などにも受け付けませんでした．当該ウィンドウのメッセージハンドラにキー入力メッセージをAviUtlのメインウィンドウに丸投げする処理を書いておきました．

   (ii) について，私は AviUtl を1枚のウィンドウに収めるのではなく，いくつかのグループにドッキングして使いたい派なのですが，その時にサブウィンドウの名前が一度何かにドッキングしないと変更できないのが不便に感じたので，タイトルの右クリックメニューに項目を追加しました．

   (iii) について，レイアウトを構築していくとき不便だと感じていたので修正しました．

   (iv) はどちらかというと (ii) の副産物です．`SubWindow` に右クリックメニューを追加するタイミングに `init()` 関数を定義したのですが，`MainWindow` の `init()` 関数を参考にしたついでです．デフォルトのアイコンよりもちょっときれいになったと思います．

4. その他小さな修正．
   1. `WinUtility.h` の `isAncestor()` 関数は Win32 API の `IsChild()` 関数を使うほうが手短になると思います．
   2. `Window.h` の `subclassProc()` 関数に明らかに無駄な関数呼び出しがあったので無効化しました．おそらくはデバッグ用コードのコメントアウト忘れだと思いますが，呼び出される頻度の高い部分なので無効化したほうがいいと思いました．

以上です．ご確認していただければと思います．